### PR TITLE
traefik[letsencypt]: Certificate auto-issue and auto-renewal support

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,6 @@ PGID=1000
 # Custom domain and certificates
 #
 DOMAIN=crismiranda.net
-LETSENCRYPT=/etc/letsencrypt
 SSL_ACME_EMAIL=crism60@gmail.com
 
 #

--- a/README.md
+++ b/README.md
@@ -41,24 +41,3 @@ Watchtower automatically updates all apps (if docker image update is available) 
 <p align="center">
   <img src="https://imgur.com/nsEsoKw.png" />
 </p>
-
-## Let's Encrypt
-As per [certbot instructions](https://certbot.eff.org/instructions), before issuing a new certificate you must stop the web server running on your machine: `docker-compose down` will do it.
-
-### Get a new certificate
-```bash
-# Install snapd
-sudo apt install snapd
-
-# Install certbot
-sudo snap install --classic certbot
-
-# Run certbot
-sudo certbot certonly --standalone
-```
-
-### Renew an existing certificate
-```bash
-# Run certbot
-sudo certbot renew
-```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,9 @@ services:
       - --entrypoints.web.http.redirections.entrypoint.permanent=true
       - --certificatesresolvers.myresolver.acme.tlschallenge=true
       - --certificatesresolvers.myresolver.acme.email=${SSL_ACME_EMAIL}
-      - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.myresolver.acme.storage=acme.json
+      - --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
     volumes:
-      - ${LETSENCRYPT}:/letsencrypt
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       default:


### PR DESCRIPTION
Traefik already supports Let's Encrypt integration out of the box :sunglasses:  